### PR TITLE
[build] Replace libtinfo-dev with libncurses-dev in package dependencies

### DIFF
--- a/.github/workflows/scripts/ti_build/ospkg.py
+++ b/.github/workflows/scripts/ti_build/ospkg.py
@@ -24,7 +24,7 @@ UBUNTU_PACKAGES = {
     "liblz4-dev",
     "libpng-dev",
     "libssl-dev",
-    "libtinfo-dev",
+    "libncurses-dev",
     "libwayland-dev",
     "libx11-xcb-dev",
     "libxcb-dri3-dev",


### PR DESCRIPTION
Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
